### PR TITLE
refactor(cli): Update CLI Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A list of things to resolve before marking this adapter as "stable".
 - [x] Make catalog faster.
 - [ ] Add views to catalog.
 - [ ] Add test(s) that create keyspaces, tables.
-- [ ] Add an option to set the protocol level manually.
+- [x] Add an option to set the protocol level manually.
 - [ ] Add an option to support execution profiles.
 - [ ] Add an option to support load-balancing policies.
 - [ ] Add an option to support consistency levels.

--- a/src/harlequin_cassandra/cli_options.py
+++ b/src/harlequin_cassandra/cli_options.py
@@ -6,6 +6,18 @@ from harlequin.options import (
     TextOption,
 )
 
+
+def _int_validator(s: str | None) -> tuple[bool, str]:
+    if s is None:
+        return True, ""
+    try:
+        _ = int(s)
+    except ValueError:
+        return False, f"Cannot convert {s} to an int!"
+    else:
+        return True, ""
+
+
 host = TextOption(
     name="host",
     description=(
@@ -26,14 +38,14 @@ port = TextOption(
 keyspace = TextOption(
     name="keyspace",
     description=("The keyspace name to use when connecting with the Cassandra server."),
-    short_decls=["-k", "--keyspace"],
+    short_decls=["-k"],
 )
 
 
-user = TextOption(
+username = TextOption(
     name="username",
     description=("Cassandra user name to connect as."),
-    short_decls=["-u", "--user", "-U"],
+    short_decls=["-u"],
 )
 
 
@@ -42,10 +54,14 @@ password = TextOption(
     description=("Password to be used if the server demands password authentication."),
 )
 
-cassandra_OPTIONS = [
-    host,
-    port,
-    keyspace,
-    user,
-    password
-]
+protocol_version = TextOption(
+    name="protocol-version",
+    description=(
+        "The maximum version of the native protocol to use. "
+        "If not specified, will be auto-discovered by the driver."
+    ),
+    short_decls=["-P"],
+    validator=_int_validator,
+)
+
+cassandra_OPTIONS = [host, port, keyspace, username, password, protocol_version]


### PR DESCRIPTION
Adding `--protocol-version` argument which allows setting the protocol
version manually.

Fixing short declarations.

Implemt `--keyspace` functionality.
