### PR TITLE
feat(tests): Improve Testing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+---
+services:
+  db:
+    image: docker.io/cassandra:4.0.13
+    restart: always
+    environment:
+      CASSANDRRA_DC: test
+      CASSANDRRA_RACK: harlequin
+    volumes:
+      - data:/var/lib/cassandra
+    ports:
+      - 9042:9042
+
+volumes:
+  data:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,7 +1,8 @@
+import os
 import sys
+from types import NoneType
 
 import pytest
-import pdb
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
 from harlequin.catalog import Catalog, CatalogItem
 from harlequin.exception import HarlequinConnectionError, HarlequinQueryError
@@ -17,12 +18,20 @@ else:
     from importlib.metadata import entry_points
 
 TEST_AUTH_OPTIONS = {
-    "username": "cassandra",
-    "password": "cassandra",
+    "username": os.environ.get("HARLEQUIN_CASSANDRA_TEST_USERNAME")
+    if os.environ.get("HARLEQUIN_CASSANDRA_TEST_USERNAME")
+    else "cassandra",
+    "password": os.environ.get("HARLEQUIN_CASSANDRA_TEST_PASSWORD")
+    if os.environ.get("HARLEQUIN_CASSANDRA_TEST_PASSWORD")
+    else "cassandra",
 }
 TEST_CONNECTION_OPTIONS = {
-    "host": "localhost",
-    "port": "9042",
+    "host": os.environ.get("HARLEQUIN_CASSANDRA_TEST_HOST")
+    if os.environ.get("HARLEQUIN_CASSANDRA_TEST_HOST")
+    else "localhost",
+    "port": os.environ.get("HARLEQUIN_CASSANDRA_PORT")
+    if os.environ.get("HARLEQUIN_CASSANDRA_PORT")
+    else "9042",
 }
 
 
@@ -90,9 +99,7 @@ def test_execute_select_dupe_cols(connection: HarlequinCassandraConnection) -> N
 
 
 def test_set_limit(connection: HarlequinCassandraConnection) -> None:
-    session = connection.execute(
-        "SELECT keyspace_name FROM system_schema.tables;"
-    )
+    session = connection.execute("SELECT keyspace_name FROM system_schema.tables;")
     assert isinstance(session, HarlequinCursor)
     session = session.set_limit(2)
     assert isinstance(session, HarlequinCursor)
@@ -106,3 +113,128 @@ def test_execute_raises_query_error(connection: HarlequinCassandraConnection) ->
     session = connection.execute("selec;")
     with pytest.raises(HarlequinQueryError):
         _ = session.fetchall()
+
+
+# TODO: (vkhitrin) most likely a fixture should be created that will autocreate
+#       keyspace(s)
+def test_create_keyspace(connection: HarlequinCassandraConnection) -> None:
+    session = connection.execute(
+        """
+        CREATE KEYSPACE IF NOT EXISTS test 
+        WITH replication = {'class':'SimpleStrategy', 'replication_factor' : 1};
+        """
+    )
+    assert isinstance(session, HarlequinCursor)
+    data = session.fetchall()
+    assert isinstance(data, NoneType)
+
+
+def test_create_keyspace_raise_query_error(
+    connection: HarlequinCassandraConnection,
+) -> None:
+    session = connection.execute(
+        """
+        CREATE KEYSPACE IF NOT EXISTS test 
+        WITH replication = {'class':'SimpleStrategy', 'replication_factor' : 1};
+        """
+    )
+    assert isinstance(session, HarlequinCursor)
+    session.fetchall()
+    session = connection.execute(
+        """
+        CREATE KEYSPACE test 
+        WITH replication = {'class':'SimpleStrategy', 'replication_factor' : 1};
+        """
+    )
+    with pytest.raises(HarlequinQueryError):
+        _ = session.fetchall()
+
+
+def test_create_table(connection: HarlequinCassandraConnection) -> None:
+    session = connection.execute(
+        """
+        CREATE KEYSPACE IF NOT EXISTS test 
+        WITH replication = {'class':'SimpleStrategy', 'replication_factor' : 1};
+        """
+    )
+    assert isinstance(session, HarlequinCursor)
+    session.fetchall()
+    session = connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS test.mocktable (
+            id text PRIMARY KEY,
+            name text,
+            position int);
+        """
+    )
+    data = session.fetchall()
+    assert isinstance(data, NoneType)
+
+
+def test_create_table_raise_query_error(
+    connection: HarlequinCassandraConnection,
+) -> None:
+    session = connection.execute(
+        """
+        CREATE KEYSPACE IF NOT EXISTS test 
+        WITH replication = {'class':'SimpleStrategy', 'replication_factor' : 1};
+        """
+    )
+    assert isinstance(session, HarlequinCursor)
+    session = connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS test.mocktable (
+            id text PRIMARY KEY,
+            name text,
+            position int);
+        """
+    )
+    session.fetchall()
+    session = connection.execute(
+        """
+        CREATE TABLE test.mocktable (
+            id text PRIMARY KEY,
+            name text,
+            position int);
+        """
+    )
+    with pytest.raises(HarlequinQueryError):
+        _ = session.fetchall()
+
+
+def test_insert_into_table(connection: HarlequinCassandraConnection) -> None:
+    session = connection.execute("DROP KEYSPACE IF EXISTS test")
+    assert isinstance(session, HarlequinCursor)
+    session.fetchall()
+    session = connection.execute(
+        """
+        CREATE KEYSPACE IF NOT EXISTS test 
+        WITH replication = {'class':'SimpleStrategy', 'replication_factor' : 1};
+        """
+    )
+    assert isinstance(session, HarlequinCursor)
+    session.fetchall()
+    session = connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS test.mocktable (
+            id text PRIMARY KEY,
+            name text,
+            position int);
+        """
+    )
+    session.fetchall()
+    session = connection.execute(
+        """
+        INSERT INTO test.mocktable (
+            id,name, position)
+        VALUES ('primary_key', 'test', 1)
+        IF NOT EXISTS;
+        """
+    )
+    session.fetchall()
+    session = connection.execute("SELECT * FROM test.mocktable;")
+    data = session.fetchall()
+    assert len(session.columns()) == 3
+    backend = create_backend(data)
+    assert backend.column_count == 3
+    assert backend.row_count == 1


### PR DESCRIPTION
Add a `docker-compose.yaml` to start a single node Cassandra cluster.

Adding tests that create a keyspace,table and insert data.
