### PR TITLE
fix(adapter): Converts Cassandra Types To Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some quirks are to be expected.
 
 A list of things to resolve before marking this adapter as "stable".
 
-- [ ] Debug issues raised by Arrow during certain `SELECT` statements.
+- [x] Debug issues raised by Arrow during certain `SELECT` statements.
 - [x] Make catalog faster.
 - [ ] Add views to catalog.
 - [ ] Add test(s) that create keyspaces, tables.


### PR DESCRIPTION
Cassndra driver may return results in a native Cassandra type which is
not mapped correctly to Arrow types.
This commit ensures that Cassandra types are converted to Python types.

Resolves #7.
